### PR TITLE
Add /doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
If use the repo as a submodule with pathogen and call pathogen#helptags(), it creates a /doc/tags file in the repo, which shows up as modified content. Adding it to the gitignore fixes the issue.
