### PR TITLE
Dont track doc/tags

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,0 @@
-sparkup-examples	sparkup.txt	/*sparkup-examples*
-sparkup-usage	sparkup.txt	/*sparkup-usage*
-sparkup-introduction	sparkup.txt	/*sparkup-introduction*
-sparkup.txt	sparkup.txt	/*sparkup.txt*


### PR DESCRIPTION
Thanks for accepting my PR to add /doc/tags to the .gitignore. I forgot to `git rm` it, which is required to fix the issue.

---

doc/tags is a file generated by the :helptags command.
If you track doc/tags and change the documentation, you'd have to
regenerate this file every time and commit it or users would get
warnings about doc/tags having modified content.
The better option is to add the file to the .gitignore (as done by
previous commit) and if it's already being tracked by git, stop tracking
it via `git rm`.
