### PR TITLE
Add a deprecation warning to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@ Sparkup for Vim
 ==============
 Just the vim version of [Sparkup](https://github.com/rstacruz/sparkup) tailored for easy installation with pathogen.
 
+Deprecation Warning
+-------------------
+The main Sparkup repository now includes easy [installation
+instructions](https://github.com/rstacruz/sparkup/tree/master/vim) for pathogen
+and Vundle-style plugin managers.
+
+Due to this, there is no longer any reason to maintain this repository. It will
+remain here for legacy users, but in order to receive updates, users should
+uninstall this and install the main Sparkup repository instead.
+
 Installation
 ------------
 Like [@tpope](http://github.com/tpope) says:


### PR DESCRIPTION
Now that the main sparkup repo has simple installation instructions for
most plugin managers, there is no need to maintain this as a separate
project. Add a note to the readme explaining the situation and directing
users to install the main sparkup plugin.

refs #17 on tristen/vim-sparkup
